### PR TITLE
Have empty field for CSV payout date (parity)

### DIFF
--- a/Settlement/Conversion.ts
+++ b/Settlement/Conversion.ts
@@ -25,7 +25,7 @@ export namespace Conversion {
 			result += `"${settlement.merchant}",`
 			result += `"${settlement.period.start}",`
 			result += `"${settlement.period.end}",`
-			result += `"${settlement.payout}",`
+			result += `"${settlement.payout ?? ""}",`
 			result += `"${isoly.Currency.round(settlement.net - (settlement.reserve?.amount ?? 0), settlement.currency)}",`
 			result += `"${settlement.reserve?.payout ?? ""}",`
 			result += `"${settlement.reserve?.amount ?? 0}",`


### PR DESCRIPTION
Before it said "undefined" when there was no payout date